### PR TITLE
Properly Fold Async Results Back into Main Stream

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "452b7e04a8f424934dbd320740d9e81c3205f6040fcc713599870ae4515233a4",
+  "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,19 @@ let package = Package(
             ]
         ),
     ],
+    dependencies: [
+        .package(
+            url: "https://github.com/pointfreeco/combine-schedulers",
+            .upToNextMajor(from: "1.0.3")
+        ),
+    ],
     targets: [
-        .target(name: "FeatureComposer"),
+        .target(
+            name: "FeatureComposer",
+            dependencies: [
+                .product(name: "CombineSchedulers", package: "combine-schedulers")
+            ]
+        ),
         .target(name: "FeatureComposerTestingSupport"),
         .testTarget(
             name: "FeatureComposerTests",

--- a/Sources/FeatureComposer/Domain/DynamicState.swift
+++ b/Sources/FeatureComposer/Domain/DynamicState.swift
@@ -1,0 +1,15 @@
+import Combine
+import Foundation
+
+@dynamicMemberLookup
+public struct DynamicState<State> {
+    private let stream: CurrentValueSubject<State, Never>
+    
+    init(stream: CurrentValueSubject<State, Never>) {
+        self.stream = stream
+    }
+    
+    public subscript<T>(dynamicMember keyPath: KeyPath<State, T>) -> T {
+        stream.value[keyPath: keyPath]
+    }
+}

--- a/Sources/FeatureComposer/Domain/Emission.swift
+++ b/Sources/FeatureComposer/Domain/Emission.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct Emission<State> {
     public enum Kind {
         case state
-        case perform(work: @Sendable (State) async -> State)
+        case perform(work: @Sendable () async -> State)
         case observe(publisher: AnyPublisher<State, Never>)
     
     }
@@ -16,7 +16,7 @@ public struct Emission<State> {
     }
     
     public static func perform(
-        work: @Sendable @escaping (State) async -> State
+        work: @Sendable @escaping () async -> State
     ) -> Emission {
         Emission(kind: .perform(work: work))
     }

--- a/Sources/FeatureComposer/Domain/Emission.swift
+++ b/Sources/FeatureComposer/Domain/Emission.swift
@@ -5,7 +5,7 @@ public struct Emission<State> {
     public enum Kind {
         case state
         case perform(work: @Sendable () async -> State)
-        case observe(publisher: AnyPublisher<State, Never>)
+        case observe(publisher: (DynamicState<State>) -> AnyPublisher<State, Never>)
     
     }
 
@@ -22,8 +22,8 @@ public struct Emission<State> {
     }
     
     public static func observe(
-        _ publisher: AnyPublisher<State, Never>
+        _ builder: @escaping (DynamicState<State>) -> AnyPublisher<State, Never>
     ) -> Emission {
-        Emission(kind: .observe(publisher: publisher))
+        Emission(kind: .observe(publisher: builder))
     }
 }

--- a/Sources/FeatureComposer/Domain/Interact.swift
+++ b/Sources/FeatureComposer/Domain/Interact.swift
@@ -21,7 +21,6 @@ public struct Interact<State: Equatable, Action>: Interactor {
     public func interact(_ upstream: AnyPublisher<Action, Never>) -> AnyPublisher<State, Never> {
         upstream
             .feedback(initialState: initialValue, handler: handler)
-            .prepend(initialValue)
             .eraseToAnyPublisher()
     }
 }

--- a/Sources/FeatureComposer/Internal/Combine/Combine+Async.swift
+++ b/Sources/FeatureComposer/Internal/Combine/Combine+Async.swift
@@ -1,0 +1,111 @@
+import Combine
+import Foundation
+
+extension Publisher {
+    func async(
+        work: @escaping @Sendable () async -> Output
+    ) -> Publishers.Async<Output, Failure> {
+        Publishers.Async<Output, Failure>(work)
+    }
+}
+
+extension Publishers {
+    /// A publisher that performs a piece of asynchronous work, returns its result, then completes.
+    ///
+    /// Adapted from: https://stackoverflow.com/questions/78892734/getting-task-isolated-value-of-type-async-passed-as-a-strongly-trans
+    struct Async<Output, Failure: Error>: Publisher, Sendable {
+        private let work: @Sendable () async -> Output
+        
+        init(
+            _ work: @escaping @Sendable () async -> Output
+        ) {
+            self.work = work
+        }
+        
+        func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input, S: Sendable {
+            let subscription = AsyncPublisherSubscription(
+                subscriber: subscriber,
+                work: work
+            )
+            subscriber.receive(subscription: subscription)
+        }
+    }
+}
+
+
+
+private extension Publishers.Async {
+    final class AsyncPublisherSubscription<S: Subscriber>: Subscription, @unchecked Sendable where S.Input == Output, S.Failure == Failure, S: Sendable {
+        private let lock = NSLock()
+        
+        private var subscriber: S?
+        private var task: Task<Void, Never>?
+        private var result: Output?
+        private var demand: Subscribers.Demand = .none
+        
+        init(
+            subscriber: S,
+            work: @escaping @Sendable () async -> Output
+        ) {
+            self.subscriber = subscriber
+            task = Task { [weak self] in
+                let value = await work()
+                self?.publisherProvided(value)
+            }
+        }
+        
+        func cancel() {
+            lock.withLock {
+                task?.cancel()
+                task = nil
+                subscriber = nil
+            }
+        }
+        
+        func request(_ demand: Subscribers.Demand) {
+            subscriberRequested(demand)
+        }
+    }
+}
+
+private extension Publishers.Async.AsyncPublisherSubscription {
+    /// Publisher has provided a result
+    ///
+    /// If subscriber has already requested a result, then just send it.
+    /// If subscriber has not yet requested result, then just save this result for future reference.
+    func publisherProvided(_ result: Output) {
+        defer { lock.unlock() }
+        lock.withLock {
+            if demand > .none {
+                sendOutputToSubscriber(result: result)
+            } else {
+                self.result = result
+            }
+        }
+    }
+    
+    /// Subscriber has requested value
+    ///
+    /// If publisher has already provided a result and subscriber demand > .none, then send it.
+    /// If publisher has not, just update the local demand count.
+    func subscriberRequested(_ demand: Subscribers.Demand) {
+        defer { lock.unlock() }
+        lock.withLock {
+            self.demand += demand
+            if let result, self.demand > .none {
+                sendOutputToSubscriber(result: result)
+            }
+        }
+    }
+    
+    /// Send output to subscriber
+    ///
+    /// Called only when both of the following are satisfied:
+    ///    * publisher has provided a result to be sent; and
+    ///    * subscriber has requested demand.
+    func sendOutputToSubscriber(result: Output) {
+        demand -= 1
+        _ = subscriber?.receive(result)
+        subscriber?.receive(completion: .finished)
+    }
+}

--- a/Sources/FeatureComposer/Internal/Combine/Combine+FeedbackLoop.swift
+++ b/Sources/FeatureComposer/Internal/Combine/Combine+FeedbackLoop.swift
@@ -43,9 +43,8 @@ extension Publisher where Failure == Never {
             return Just(feedbackState.state)
                 .eraseToAnyPublisher()
         case let .perform(work):
-            // TODO: - Spin Up Async Publisher Here
-            return Just(feedbackState.state)
-                // .prepend(feedbackState.state)
+            return Publishers.Async(work)
+                .prepend(feedbackState.state)
                 .eraseToAnyPublisher()
         case let .observe(publisher):
             return publisher

--- a/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/AsyncCounterInteractor.swift
+++ b/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/AsyncCounterInteractor.swift
@@ -1,0 +1,35 @@
+import CombineSchedulers
+import Foundation
+@testable import FeatureComposer
+
+struct AsyncCounterInteractor: Interactor {
+    struct State: Equatable, Sendable {
+        var count: Int
+    }
+
+    enum Action: Sendable {
+        case increment
+        case async
+    }
+    
+    private let scheduler: AnySchedulerOf<DispatchQueue>
+    
+    init(scheduler: AnySchedulerOf<DispatchQueue>) {
+        self.scheduler = scheduler
+    }
+    
+    var body: some InteractorOf<Self> {
+        Interact<State, Action>(initialValue: State(count: 0)) { state, action in
+            switch action {
+            case .increment:
+                state.count += 1
+                return .state
+            case .async:
+                return .perform { [count = state.count] in
+                    try? await scheduler.sleep(for: .seconds(0.5))
+                    return AsyncCounterInteractor.State(count: count + 1)
+                }
+            }
+        }
+    }
+}

--- a/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/AsyncCounterInteractorTests.swift
+++ b/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/AsyncCounterInteractorTests.swift
@@ -1,0 +1,42 @@
+import Combine
+import CombineSchedulers
+import Foundation
+@testable import FeatureComposer
+import Testing
+
+@Suite
+final class AsyncCounterInteractorTests {
+    private let subject = PassthroughSubject<AsyncCounterInteractor.Action, Never>()
+    private var cancellables: Set<AnyCancellable> = []
+    
+    private let counterInteractor: AsyncCounterInteractor
+    private let scheduler = DispatchQueue.test
+    
+    init() {
+        self.counterInteractor = AsyncCounterInteractor(
+            scheduler: scheduler.eraseToAnyScheduler()
+        )
+    }
+    
+    @Test func asyncWork() async {
+        let expected: [AsyncCounterInteractor.State] = [
+            .init(count: 0),
+            .init(count: 1),
+            .init(count: 1),
+            .init(count: 2)
+        ]
+        
+        counterInteractor
+            .interact(subject.eraseToAnyPublisher())
+            .collect()
+            .sink { actual in
+                #expect(actual == expected)
+            }
+            .store(in: &cancellables)
+        
+        subject.send(.increment)
+        subject.send(.async)
+        await scheduler.advance(by: .seconds(0.5))
+        subject.send(completion: .finished)
+    }
+}

--- a/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/AsyncCounterInteractorTests.swift
+++ b/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/AsyncCounterInteractorTests.swift
@@ -22,8 +22,8 @@ final class AsyncCounterInteractorTests {
         let expected: [AsyncCounterInteractor.State] = [
             .init(count: 0),
             .init(count: 1),
-            .init(count: 1),
-            .init(count: 2)
+            .init(count: 2),
+            .init(count: 3)
         ]
         
         counterInteractor
@@ -37,6 +37,7 @@ final class AsyncCounterInteractorTests {
         subject.send(.increment)
         subject.send(.async)
         await scheduler.advance(by: .seconds(0.5))
+        subject.send(.increment)
         subject.send(completion: .finished)
     }
 }

--- a/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/HotCounterInteractor.swift
+++ b/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/HotCounterInteractor.swift
@@ -19,11 +19,13 @@ struct HotCounterInteractor: Interactor {
                 state.count += 1
                 return .state
             case let .observe(publisher):
-                let statePublisher = publisher
-                    .map { [count = state.count] int in
-                        State(count: count + int)
-                    }
-                return .observe(statePublisher.eraseToAnyPublisher())
+                return .observe { state in
+                    let statePublisher = publisher
+                        .map { int in
+                            State(count: state.count + int)
+                        }
+                    return statePublisher.eraseToAnyPublisher()
+                }
             }
         }
     }

--- a/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/HotCounterInteractor.swift
+++ b/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/HotCounterInteractor.swift
@@ -1,0 +1,30 @@
+@preconcurrency import Combine
+import Foundation
+@testable import FeatureComposer
+
+struct HotCounterInteractor: Interactor {
+    struct State: Equatable, Sendable {
+        var count: Int
+    }
+
+    enum Action: Sendable {
+        case increment
+        case observe(AnyPublisher<Int, Never>)
+    }
+    
+    var body: some InteractorOf<Self> {
+        Interact<State, Action>(initialValue: State(count: 0)) { state, action in
+            switch action {
+            case .increment:
+                state.count += 1
+                return .state
+            case let .observe(publisher):
+                let statePublisher = publisher
+                    .map { [count = state.count] int in
+                        State(count: count + int)
+                    }
+                return .observe(statePublisher.eraseToAnyPublisher())
+            }
+        }
+    }
+}

--- a/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/HotCounterInteractorTests.swift
+++ b/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/HotCounterInteractorTests.swift
@@ -13,7 +13,10 @@ final class HotCounterInteractorTests {
     @Test func asyncWork() async {
         let expected: [HotCounterInteractor.State] = [
             .init(count: 0),
-            .init(count: 1)
+            .init(count: 1),
+            .init(count: 2),
+            .init(count: 4),
+            .init(count: 5)
         ]
         
         counterInteractor
@@ -30,7 +33,8 @@ final class HotCounterInteractorTests {
         subject.send(.observe(intPublisher.eraseToAnyPublisher()))
         intPublisher.send(1)
         intPublisher.send(2)
-        intPublisher.send(3)
+        
+        subject.send(.increment)
         intPublisher.send(completion: .finished)
         subject.send(completion: .finished)
     }

--- a/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/HotCounterInteractorTests.swift
+++ b/Tests/FeatureComposerTests/DomainTests/InteractorTests/CounterInteractors/HotCounterInteractorTests.swift
@@ -1,0 +1,37 @@
+import Combine
+import Foundation
+@testable import FeatureComposer
+import Testing
+
+@Suite
+final class HotCounterInteractorTests {
+    private let subject = PassthroughSubject<HotCounterInteractor.Action, Never>()
+    private var cancellables: Set<AnyCancellable> = []
+    
+    private let counterInteractor = HotCounterInteractor()
+    
+    @Test func asyncWork() async {
+        let expected: [HotCounterInteractor.State] = [
+            .init(count: 0),
+            .init(count: 1)
+        ]
+        
+        counterInteractor
+            .interact(subject.eraseToAnyPublisher())
+            .collect()
+            .sink { actual in
+                #expect(actual == expected)
+            }
+            .store(in: &cancellables)
+        
+        subject.send(.increment)
+        
+        let intPublisher = PassthroughSubject<Int, Never>()
+        subject.send(.observe(intPublisher.eraseToAnyPublisher()))
+        intPublisher.send(1)
+        intPublisher.send(2)
+        intPublisher.send(3)
+        intPublisher.send(completion: .finished)
+        subject.send(completion: .finished)
+    }
+}


### PR DESCRIPTION
Solving the problem of how to make sure long running effects update our source of truth for the current state. Using a `CurrentValueSubject` and `handleEvents` to do this for now, will revisit with a more pure Combine approach in the future.