### PR TITLE
IS/22 - Add VSReducer Macro

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "92b4256e854d98727e90b8c7d62c485ae047563efc9761b5560d7bf9ef17d62b",
+  "originHash" : "2a5fe0bbc6827e61d6154c549212dccfc792d995e32d9754809fd7aac63d46df",
   "pins" : [
     {
       "identity" : "combine-schedulers",

--- a/Sources/DomainArchitecture/Macros.swift
+++ b/Sources/DomainArchitecture/Macros.swift
@@ -8,3 +8,14 @@
 @attached(memberAttribute)
 @attached(extension, conformances: Interactor)
 public macro Interactor() = #externalMacro(module: "DomainArchitectureMacros", type: "InteractorMacro")
+
+@attached(
+    member,
+    names:
+        named(body),
+    named(DomainState),
+    named(ViewState)
+)
+@attached(memberAttribute)
+@attached(extension, conformances: ViewStateReducer)
+public macro ViewStateReducer() = #externalMacro(module: "DomainArchitectureMacros", type: "ViewStateReducerMacro")

--- a/Sources/DomainArchitecture/Presentation/ViewStateReducer/ViewStateReducer.swift
+++ b/Sources/DomainArchitecture/Presentation/ViewStateReducer/ViewStateReducer.swift
@@ -24,6 +24,14 @@ extension ViewStateReducer where Body.DomainState == Never {
     }
 }
 
+extension ViewStateReducer {
+    public static func buildViewState(
+        reducerBlock: @escaping (DomainState) -> ViewState
+    ) -> BuildViewState<DomainState, ViewState> {
+        BuildViewState(reducerBlock: reducerBlock)
+    }
+}
+
 extension ViewStateReducer where Body: ViewStateReducer<DomainState, ViewState> {
     public func reduce(
         _ upstream: AnyPublisher<DomainState, Never>

--- a/Sources/DomainArchitectureMacros/Plugins/Plugin.swift
+++ b/Sources/DomainArchitectureMacros/Plugins/Plugin.swift
@@ -4,6 +4,7 @@ import SwiftSyntaxMacros
 @main
 struct MacrosPlugin: CompilerPlugin {
     let providingMacros: [any Macro.Type] = [
-        InteractorMacro.self
+        InteractorMacro.self,
+        ViewStateReducerMacro.self,
     ]
 }

--- a/Tests/DomainArchitectureMacrosTests/InteractorMacroTests.swift
+++ b/Tests/DomainArchitectureMacrosTests/InteractorMacroTests.swift
@@ -6,7 +6,7 @@
     final class InteractorMacroTests: XCTestCase {
         override func invokeTest() {
             withMacroTesting(
-                //                record: .failed,
+                //                                record: .failed,
                 macros: [InteractorMacro.self]
             ) {
                 super.invokeTest()
@@ -115,7 +115,7 @@
                 struct MyInteractor {
                     typealias DomainState = Int
                     ┬──────────────────────────
-                    ╰─ ⚠️ Consider removing explicit `typealias Action = Int`. This is handled by the `@Interactor` macro.
+                    ╰─ ⚠️ Consider removing explicit `typealias DomainState = Int`. This is handled by the `@Interactor` macro.
                     typealias Action = String
                     ┬────────────────────────
                     ╰─ ⚠️ Consider removing explicit `typealias Action = String`. This is handled by the `@Interactor` macro.

--- a/Tests/DomainArchitectureMacrosTests/ViewStateReducerMacroTests.swift
+++ b/Tests/DomainArchitectureMacrosTests/ViewStateReducerMacroTests.swift
@@ -1,0 +1,220 @@
+#if canImport(DomainArchitectureMacros)
+    import DomainArchitectureMacros
+    import MacroTesting
+    import XCTest
+
+    final class ViewStateReducerMacroTests: XCTestCase {
+        override func invokeTest() {
+            withMacroTesting(
+                record: .failed,
+                macros: [ViewStateReducerMacro.self]
+            ) {
+                super.invokeTest()
+            }
+        }
+
+        func testBasics_NoGenericsInMacro() {
+            assertMacro {
+                """
+                @ViewStateReducer
+                struct MyViewStateReducer {
+                    var body: some ViewStateReducer<MyDomainState, MyViewState> {
+                        BuildViewState<MyDomainState, MyViewState> { .none }
+                    }
+                }
+                """
+            } expansion: {
+                """
+                struct MyViewStateReducer {
+                    @DomainArchitecture.ViewStateReducerBuilder<MyDomainState, MyViewState>
+                    var body: some ViewStateReducer<MyDomainState, MyViewState> {
+                        BuildViewState<MyDomainState, MyViewState> { .none }
+                    }
+                }
+
+                extension MyViewStateReducer: DomainArchitecture.ViewStateReducer {
+                }
+                """
+            }
+        }
+
+        func testBasics_NoGenericsInMacro_NestedStateAndAction() {
+            assertMacro {
+                """
+                @ViewStateReducer
+                struct MyViewStateReducer {
+                    enum DomainState {}
+                    enum ViewState {}
+                    var body: some ViewStateReducerOf<Self> {
+                        BuildViewState<DomainState, ViewState> { .none }
+                    }
+                }
+                """
+            } expansion: {
+                """
+                struct MyViewStateReducer {
+                    enum DomainState {}
+                    enum ViewState {}
+                    @DomainArchitecture.ViewStateReducerBuilder<Self.DomainState, Self.ViewState>
+                    var body: some ViewStateReducerOf<Self> {
+                        BuildViewState<DomainState, ViewState> { .none }
+                    }
+                }
+
+                extension MyViewStateReducer: DomainArchitecture.ViewStateReducer {
+                }
+                """
+            }
+        }
+
+        func testBasics_GenericsInMacro() {
+            assertMacro {
+                """
+                @ViewStateReducer<Int, String>
+                struct MyViewStateReducer {
+                    var body: some ViewStateReducerOf<Self> {
+                        BuildViewState { .none }
+                    }
+                }
+                """
+            } expansion: {
+                """
+                struct MyViewStateReducer {
+                    @DomainArchitecture.ViewStateReducerBuilder<Int, String>
+                    var body: some ViewStateReducerOf<Self> {
+                        BuildViewState { .none }
+                    }
+
+                    typealias DomainState = Int
+
+                    typealias ViewState = String
+                }
+
+                extension MyViewStateReducer: DomainArchitecture.ViewStateReducer {
+                }
+                """
+            }
+        }
+
+        func testBasics_GenericsInMacro_ExistingTypealias_EmitsWarning() {
+            assertMacro {
+                """
+                @ViewStateReducer<Int, String>
+                struct MyViewStateReducer {
+                    typealias DomainState = Int
+                    typealias ViewState = String
+
+                    var body: some ViewStateReducerOf<Self> {
+                        BuildViewState { .none }
+                    }
+                }
+                """
+            } diagnostics: {
+                """
+                @ViewStateReducer<Int, String>
+                struct MyViewStateReducer {
+                    typealias DomainState = Int
+                    ┬──────────────────────────
+                    ╰─ ⚠️ Consider removing explicit `typealias DomainState = Int`. This is handled by the `@ViewStateReducer` macro.
+                    typealias ViewState = String
+                    ┬───────────────────────────
+                    ╰─ ⚠️ Consider removing explicit `typealias ViewState = String`. This is handled by the `@ViewStateReducer` macro.
+
+                    var body: some ViewStateReducerOf<Self> {
+                        BuildViewState { .none }
+                    }
+                }
+                """
+            } expansion: {
+                """
+                struct MyViewStateReducer {
+                    typealias DomainState = Int
+                    typealias ViewState = String
+                    @DomainArchitecture.ViewStateReducerBuilder<Int, String>
+
+                    var body: some ViewStateReducerOf<Self> {
+                        BuildViewState { .none }
+                    }
+                }
+
+                extension MyViewStateReducer: DomainArchitecture.ViewStateReducer {
+                }
+                """
+            }
+        }
+
+        func testGenericsInMacro_EmitsError() {
+            assertMacro {
+                """
+                @ViewStateReducer<Int, String>
+                struct MyViewStateReducer {
+                    var body: some ViewStateReducer<Int1, String> {
+                        BuildViewState { .none }
+                    }
+                }
+                """
+            } diagnostics: {
+                """
+                @ViewStateReducer<Int, String>
+                struct MyViewStateReducer {
+                    var body: some ViewStateReducer<Int1, String> {
+                        ┬───
+                        ╰─ 🛑 Generic parameters have already been applied to the attached macro and will take precedence over those specified in `body`
+                           ✏️ Replace 'some ViewStateReducer<Int1, String>' with 'some ViewStateReducerOf<Self>'
+                        BuildViewState { .none }
+                    }
+                }
+                """
+            } fixes: {
+                """
+                @ViewStateReducer<Int, String>
+                struct MyViewStateReducer {
+                    var body: some ViewStateReducerOf<Self> {
+                        BuildViewState { .none }
+                    }
+                }
+                """
+            } expansion: {
+                """
+                struct MyViewStateReducer {
+                    @DomainArchitecture.ViewStateReducerBuilder<Int, String>
+                    var body: some ViewStateReducerOf<Self> {
+                        BuildViewState { .none }
+                    }
+
+                    typealias DomainState = Int
+
+                    typealias ViewState = String
+                }
+
+                extension MyViewStateReducer: DomainArchitecture.ViewStateReducer {
+                }
+                """
+            }
+        }
+
+        func testMoreThanTwoGenericsInMacro() {
+            assertMacro {
+                """
+                @ViewStateReducer<Int, String, Bool>
+                struct MyViewStateReducer {
+                    var body: some ViewStateReducer<Int1, String> {
+                        BuildViewState { .none }
+                    }
+                }
+                """
+            } diagnostics: {
+                """
+                @ViewStateReducer<Int, String, Bool>
+                 ┬──────────────────────────────────
+                 ╰─ 🛑 Only 2 generic arguments should be applied the @ViewStateReducer macro. One for the ViewStateReducer's domain state type and one for its view state type. 
+                struct MyViewStateReducer {
+                    var body: some ViewStateReducer<Int1, String> {
+                        BuildViewState { .none }
+                    }
+                }
+                """
+            }
+        }
+    }
+#endif

--- a/Tests/DomainArchitectureTests/PresentationTests/Mocks/MyViewStateReducer.swift
+++ b/Tests/DomainArchitectureTests/PresentationTests/Mocks/MyViewStateReducer.swift
@@ -1,12 +1,10 @@
 import DomainArchitecture
 import Foundation
 
-struct MyViewStateReducer: ViewStateReducer {
-    typealias DomainState = MyDomainState
-    typealias ViewState = MyViewState
-
+@ViewStateReducer<MyDomainState, MyViewState>
+struct MyViewStateReducer {
     var body: some ViewStateReducerOf<Self> {
-        BuildViewState<DomainState, ViewState> { domainState in
+        Self.buildViewState { domainState in
             switch domainState {
             case let .error(code):
                 return .error(title: reduceErrorCode(code))


### PR DESCRIPTION
Closes #22 - Add @ViewStateReducer Macro. This is basically the same as the @Interactor macro, but I kept the files separate at the expense of copy pasta in case we need to add additional functionality later.