### PR TITLE
Add enum-case scoping for ScopedViewModel projections

### DIFF
--- a/ExampleProject/ExampleProject/ContentView.swift
+++ b/ExampleProject/ExampleProject/ContentView.swift
@@ -39,6 +39,7 @@ private enum Example: String, CaseIterable, Identifiable {
     case timerLeak
     case fineGrained
     case scopedComposition
+    case enumCaseScoping
 
     var id: String { rawValue }
 
@@ -54,6 +55,8 @@ private enum Example: String, CaseIterable, Identifiable {
             "Fine-Grained Observation Example"
         case .scopedComposition:
             "Scoped Composition Example"
+        case .enumCaseScoping:
+            "Enum Case Scoping Example"
         }
     }
 
@@ -69,6 +72,8 @@ private enum Example: String, CaseIterable, Identifiable {
             "Fine-Grained"
         case .scopedComposition:
             "Scoped Composition"
+        case .enumCaseScoping:
+            "Enum Case Scoping"
         }
     }
 
@@ -85,6 +90,8 @@ private enum Example: String, CaseIterable, Identifiable {
             FineGrainedExampleAppView()
         case .scopedComposition:
             ScopedCompositionExampleAppView()
+        case .enumCaseScoping:
+            PhaseExampleAppView()
         }
     }
 }

--- a/ExampleProject/FineGrainedExamplePackage/Sources/FineGrainedExample/FineGrainedView.swift
+++ b/ExampleProject/FineGrainedExamplePackage/Sources/FineGrainedExample/FineGrainedView.swift
@@ -47,7 +47,6 @@ struct FineGrainedView: View {
 
 struct HeaderView: View {
     let viewModel: FineGrainedViewModel
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -68,7 +67,6 @@ struct HeaderView: View {
 
 struct FooterView: View {
     let viewModel: FineGrainedViewModel
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -89,7 +87,6 @@ struct FooterView: View {
 
 struct PhaseView: View {
     let viewModel: FineGrainedViewModel
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 

--- a/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseDomainState.swift
+++ b/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseDomainState.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Flat domain state; the view-state reducer projects it into the nested phase enum.
+struct PhaseDomainState: Equatable, Sendable {
+    var isLoaded: Bool = false
+    var isTicking: Bool = false
+    var isActive: Bool = false
+    var title: String = "Success"
+    var count: Int = 0
+    var sessionName: String = "Live sync"
+    var status: String = "Connected"
+    var tick: Int = 0
+    var note: String = ""
+}

--- a/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseEvent.swift
+++ b/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseEvent.swift
@@ -1,0 +1,50 @@
+import CasePaths
+import Foundation
+
+/// Child actions nest the same way the view-state slices do:
+/// `ActiveAction` ⊂ `SubphaseAction` ⊂ `TelemetryAction` ⊂ `SessionAction` ⊂ `SuccessAction`
+/// ⊂ `PhaseEvent`, with `SummaryAction` as a sibling branch under `SuccessAction`.
+@CasePathable
+enum ActiveAction: Equatable, Sendable {
+    case noteChanged(String)
+}
+
+@CasePathable
+enum SubphaseAction: Equatable, Sendable {
+    case active(ActiveAction)
+}
+
+@CasePathable
+enum TelemetryAction: Equatable, Sendable {
+    case startTapped
+    case stopTapped
+    case subphase(SubphaseAction)
+}
+
+@CasePathable
+enum SessionAction: Equatable, Sendable {
+    case telemetry(TelemetryAction)
+}
+
+@CasePathable
+enum SummaryAction: Equatable, Sendable {
+    case incremented
+}
+
+/// Actions for the success case's payload, embedded into ``PhaseEvent`` via `.success`.
+@CasePathable
+enum SuccessAction: Equatable, Sendable {
+    case titleChanged(String)
+    case summary(SummaryAction)
+    case session(SessionAction)
+}
+
+@CasePathable
+enum PhaseEvent: Equatable, Sendable {
+    case loadTapped
+    case loaded
+    case resetTapped
+    case startTicking
+    case tick
+    case success(SuccessAction)
+}

--- a/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseInteractor.swift
+++ b/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseInteractor.swift
@@ -1,0 +1,62 @@
+import Lattice
+
+@Interactor<PhaseDomainState, PhaseEvent>
+struct PhaseInteractor: Sendable {
+    var body: some InteractorOf<Self> {
+        Interact { state, event in
+            switch event {
+            case .loadTapped:
+                // Fake an async load so the .loading -> .success case change is visible.
+                return .perform {
+                    try? await ContinuousClock().sleep(for: .seconds(1))
+                    return .loaded
+                }
+
+            case .loaded:
+                state.isLoaded = true
+                return .none
+
+            case .resetTapped:
+                state.isLoaded = false
+                return .none
+
+            case .startTicking:
+                guard !state.isTicking else { return .none }
+                state.isTicking = true
+                // Once-per-second tick stream: the unrelated-reduce driver that makes the
+                // _$inert fix visible while a payloadless case (.loading or .idle) is active,
+                // and the deep-leaf driver while the .active sub-phase is showing.
+                return .observe {
+                    let clock = ContinuousClock()
+                    return AsyncStream(unfolding: {
+                        try? await clock.sleep(for: .seconds(1))
+                        return Task.isCancelled ? nil : .tick
+                    })
+                }
+
+            case .tick:
+                state.tick += 1
+                return .none
+
+            case .success(let action):
+                // Late sends after the case deactivated are dropped here, by design: the
+                // interactor is the arbiter of whether an action still applies.
+                guard state.isLoaded else { return .none }
+                switch action {
+                case .titleChanged(let title):
+                    state.title = title
+                case .summary(.incremented):
+                    state.count += 1
+                case .session(.telemetry(.startTapped)):
+                    state.isActive = true
+                case .session(.telemetry(.stopTapped)):
+                    state.isActive = false
+                case .session(.telemetry(.subphase(.active(.noteChanged(let note))))):
+                    guard state.isActive else { return .none }
+                    state.note = note
+                }
+                return .none
+            }
+        }
+    }
+}

--- a/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseViewState.swift
+++ b/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseViewState.swift
@@ -1,0 +1,58 @@
+import CasePaths
+import Foundation
+import Lattice
+
+/// The whole view state is an enum: a normal exhaustive `switch` selects the case, and
+/// `scope(state: \.success, action: \.success)` projects the matched payload into a live
+/// `ScopedViewModel`. `@CasePathable` supplies the case key paths (`@ObservableState` does
+/// not add them).
+///
+/// The success payload is a deep chain of nested `@ObservableState` slices —
+/// `Success > Session > Telemetry > Subphase > Active` — with `Summary` as a sibling branch,
+/// so the render counters can show exactly which boundaries a change crosses.
+@CasePathable
+@ObservableState
+enum PhaseViewState: Equatable, Sendable {
+    case loading
+    case success(SuccessViewState)
+}
+
+@ObservableState
+struct SuccessViewState: Equatable, Sendable {
+    var title: String
+    var summary: SummaryViewState
+    var session: SessionViewState
+}
+
+@ObservableState
+struct SummaryViewState: Equatable, Sendable {
+    var count: Int
+}
+
+@ObservableState
+struct SessionViewState: Equatable, Sendable {
+    var name: String
+    var telemetry: TelemetryViewState
+}
+
+@ObservableState
+struct TelemetryViewState: Equatable, Sendable {
+    var status: String
+    var subphase: SubphaseViewState
+}
+
+/// A nested sub-phase enum inside the success payload, case-scoped via the
+/// `ScopedViewModel.scope(state:action:)` case overload: inner case changes re-render only
+/// the inner switch subtree, never the root switch.
+@CasePathable
+@ObservableState
+enum SubphaseViewState: Equatable, Sendable {
+    case idle
+    case active(ActiveViewState)
+}
+
+@ObservableState
+struct ActiveViewState: Equatable, Sendable {
+    var tick: Int
+    var note: String
+}

--- a/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseViewStateReducer.swift
+++ b/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/Architecture/PhaseViewStateReducer.swift
@@ -1,0 +1,57 @@
+import Lattice
+
+@ViewStateReducer<PhaseDomainState, PhaseViewState>
+struct PhaseViewStateReducer {
+    func initialViewState(for domainState: PhaseDomainState) -> PhaseViewState {
+        .loading
+    }
+
+    var body: some ViewStateReducerOf<Self> {
+        // The two-regimes discipline, applied at both enum levels: mutate payloads in place
+        // while staying in a case (fine-grained; the enclosing identities are untouched and
+        // no switch re-renders), and rebuild a case wholesale only on a real transition
+        // (coarse; exactly that switch re-renders). Payloadless cases (.loading, .idle) are
+        // reassigned every reduce; their _$inert-stable ids make those assignments
+        // identity-equal no-ops.
+        Self.buildViewState { domainState, viewState in
+            guard domainState.isLoaded else {
+                viewState = .loading
+                return
+            }
+            guard viewState.is(\.success) else {
+                viewState = .success(
+                    SuccessViewState(
+                        title: domainState.title,
+                        summary: SummaryViewState(count: domainState.count),
+                        session: SessionViewState(
+                            name: domainState.sessionName,
+                            telemetry: TelemetryViewState(
+                                status: domainState.status,
+                                subphase: .idle
+                            )
+                        )
+                    )
+                )
+                return
+            }
+            viewState.modify(\.success) { success in
+                success.title = domainState.title
+                success.summary.count = domainState.count
+                success.session.name = domainState.sessionName
+                success.session.telemetry.status = domainState.status
+                if !domainState.isActive {
+                    success.session.telemetry.subphase = .idle
+                } else if success.session.telemetry.subphase.is(\.active) {
+                    success.session.telemetry.subphase.modify(\.active) {
+                        $0.tick = domainState.tick
+                        $0.note = domainState.note
+                    }
+                } else {
+                    success.session.telemetry.subphase = .active(
+                        ActiveViewState(tick: domainState.tick, note: domainState.note)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/PhaseExampleAppView.swift
+++ b/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/PhaseExampleAppView.swift
@@ -1,0 +1,23 @@
+import Lattice
+import SwiftUI
+
+public struct PhaseExampleAppView: View {
+    @State private var viewModel: PhaseExampleViewModel
+
+    public init() {
+        let feature = Feature(
+            interactor: PhaseInteractor(),
+            reducer: PhaseViewStateReducer()
+        )
+        _viewModel = State(
+            wrappedValue: ViewModel(
+                initialDomainState: PhaseDomainState(),
+                feature: feature
+            )
+        )
+    }
+
+    public var body: some View {
+        PhaseExampleView(viewModel: viewModel)
+    }
+}

--- a/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/PhaseExampleView.swift
+++ b/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/PhaseExampleView.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Lattice
+import SwiftUI
+
+typealias PhaseExampleViewModel = ViewModel<
+    Feature<PhaseEvent, PhaseDomainState, PhaseViewState>
+>
+
+/// Root of the enum-case-scoping demo: a plain exhaustive `switch` over the coarse
+/// `viewModel.viewState` read selects the outer case; `scope(state: \.success,
+/// action: \.success)` projects the matched payload into a live `ScopedViewModel`, and the
+/// children chain `scope` four levels deep (`Success > Session > Telemetry > Subphase >
+/// Active`), including an inner sub-phase enum case-scoped below the root.
+///
+/// The render counters make the observation boundaries visible:
+/// - Ticks or typing in the deep leaf (in-place payload mutation): only `ActiveView renders:`
+///   advances; every intermediate and sibling counter stays put.
+/// - Increment (sibling branch): only `SummaryView renders:` advances.
+/// - Start/Stop (inner case change): only `TelemetryView renders:` (the inner switch) and its
+///   rebuilt subtree advance; the root switch stays put.
+/// - Load/Reset (outer case change): `PhaseExampleView renders:` advances — the intended
+///   coarse channel.
+/// - Ticks while `.loading` (or `.idle`): nothing advances. This is the `_$inert` fix made
+///   visible; before it, a payloadless case minted a fresh id per access and the switch
+///   re-rendered once per second while showing an unchanged spinner.
+struct PhaseExampleView: View {
+    let viewModel: PhaseExampleViewModel
+    // ponytail: render counter is demo-only instrumentation, not a real pattern
+    private final class Renders { var count = 0 }
+    private let renders = Renders()
+
+    var body: some View {
+        renders.count += 1
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(
+                    """
+                    Each level holds a ScopedViewModel chained from the case scope and shows \
+                    its own render counter. Ticks and typing mutate the deep leaf in place — \
+                    only ActiveView re-renders. Start/Stop flips the inner sub-phase — only \
+                    the inner switch re-renders. Load/Reset flips the outer case — only then \
+                    does the root re-render. Ticks while loading re-render nothing.
+                    """
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+                switch viewModel.viewState {  // coarse read: re-renders on outer case change only
+                case .loading:
+                    ProgressView("Loading…")
+                        .frame(maxWidth: .infinity)
+                case .success:
+                    SuccessView(model: viewModel.scope(state: \.success, action: \.success))
+                }
+
+                VStack(spacing: 12) {
+                    Button("Load") { viewModel.sendViewEvent(.loadTapped) }
+                    Button("Reset") { viewModel.sendViewEvent(.resetTapped) }
+                }
+                .buttonStyle(.borderedProminent)
+                .frame(maxWidth: .infinity)
+
+                Text("PhaseExampleView renders: \(renders.count)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+        }
+        .task { await viewModel.sendViewEvent(.startTicking).finish() }
+    }
+}
+
+/// Level 1 below the outer case: reads only `title`, then hands each branch its own scope.
+/// `SummaryView` is the sibling branch that must stay put while the deep leaf ticks.
+struct SuccessView: View {
+    let model: ScopedViewModel<SuccessViewState, SuccessAction>
+    // ponytail: render counter is demo-only instrumentation, not a real pattern
+    private final class Renders { var count = 0 }
+    private let renders = Renders()
+
+    var body: some View {
+        renders.count += 1
+        return VStack(alignment: .leading, spacing: 12) {
+            TextField("Title", text: model.binding(\.title, sending: \.titleChanged))
+                .textFieldStyle(.roundedBorder)
+            SummaryView(model: model.scope(state: \.summary, action: \.summary))
+            SessionView(model: model.scope(state: \.session, action: \.session))
+            Text("SuccessView renders: \(renders.count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+/// Sibling branch: its counter advances on Increment and stays put on leaf ticks, typing,
+/// and inner case changes.
+struct SummaryView: View {
+    let model: ScopedViewModel<SummaryViewState, SummaryAction>
+    // ponytail: render counter is demo-only instrumentation, not a real pattern
+    private final class Renders { var count = 0 }
+    private let renders = Renders()
+
+    var body: some View {
+        renders.count += 1
+        return VStack(alignment: .leading, spacing: 8) {
+            Button("Increment") { model.sendViewEvent(.incremented) }
+                .buttonStyle(.bordered)
+            Text("Count: \(model.count)")
+            Text("SummaryView renders: \(renders.count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.quinary, in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+/// Level 2: reads only `name`; a thin pass-through that scopes deeper.
+struct SessionView: View {
+    let model: ScopedViewModel<SessionViewState, SessionAction>
+    // ponytail: render counter is demo-only instrumentation, not a real pattern
+    private final class Renders { var count = 0 }
+    private let renders = Renders()
+
+    var body: some View {
+        renders.count += 1
+        return VStack(alignment: .leading, spacing: 8) {
+            Text(model.name)
+                .font(.headline)
+            TelemetryView(model: model.scope(state: \.telemetry, action: \.telemetry))
+            Text("SessionView renders: \(renders.count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.quinary, in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+/// Level 3: owns the inner sub-phase switch. Reading `model.subphase` registers the sub-phase
+/// container's identity, so this view re-renders on inner case changes only — in-place leaf
+/// mutations inside `.active` do not advance its counter.
+struct TelemetryView: View {
+    let model: ScopedViewModel<TelemetryViewState, TelemetryAction>
+    // ponytail: render counter is demo-only instrumentation, not a real pattern
+    private final class Renders { var count = 0 }
+    private let renders = Renders()
+
+    var body: some View {
+        renders.count += 1
+        return VStack(alignment: .leading, spacing: 8) {
+            Text(model.status)
+
+            switch model.subphase {  // inner switch: re-renders on sub-phase case change only
+            case .idle:
+                Text("Idle")
+                    .foregroundStyle(.secondary)
+            case .active:
+                ActiveView(
+                    model: model.scope(state: \.subphase, action: \.subphase)
+                        .scope(state: \.active, action: \.active)
+                )
+            }
+
+            HStack {
+                Button("Start") { model.sendViewEvent(.startTapped) }
+                Button("Stop") { model.sendViewEvent(.stopTapped) }
+            }
+            .buttonStyle(.bordered)
+
+            Text("TelemetryView renders: \(renders.count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+/// Level 4, the deep leaf: the tick stream mutates `tick` in place once per second and the
+/// note field round-trips through a binding — only this counter advances on either.
+struct ActiveView: View {
+    let model: ScopedViewModel<ActiveViewState, ActiveAction>
+    // ponytail: render counter is demo-only instrumentation, not a real pattern
+    private final class Renders { var count = 0 }
+    private let renders = Renders()
+
+    var body: some View {
+        renders.count += 1
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Tick: \(model.tick)")
+                .font(.title3)
+            TextField("Note", text: model.binding(\.note, sending: \.noteChanged))
+                .textFieldStyle(.roundedBorder)
+            Text("ActiveView renders: \(renders.count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.quinary, in: RoundedRectangle(cornerRadius: 8))
+    }
+}

--- a/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/PhaseExampleView.swift
+++ b/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/PhaseExampleView.swift
@@ -25,7 +25,6 @@ typealias PhaseExampleViewModel = ViewModel<
 ///   re-rendered once per second while showing an unchanged spinner.
 struct PhaseExampleView: View {
     let viewModel: PhaseExampleViewModel
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -74,7 +73,6 @@ struct PhaseExampleView: View {
 /// `SummaryView` is the sibling branch that must stay put while the deep leaf ticks.
 struct SuccessView: View {
     let model: ScopedViewModel<SuccessViewState, SuccessAction>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -99,7 +97,6 @@ struct SuccessView: View {
 /// and inner case changes.
 struct SummaryView: View {
     let model: ScopedViewModel<SummaryViewState, SummaryAction>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -122,7 +119,6 @@ struct SummaryView: View {
 /// Level 2: reads only `name`; a thin pass-through that scopes deeper.
 struct SessionView: View {
     let model: ScopedViewModel<SessionViewState, SessionAction>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -147,7 +143,6 @@ struct SessionView: View {
 /// mutations inside `.active` do not advance its counter.
 struct TelemetryView: View {
     let model: ScopedViewModel<TelemetryViewState, TelemetryAction>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -187,7 +182,6 @@ struct TelemetryView: View {
 /// note field round-trips through a binding — only this counter advances on either.
 struct ActiveView: View {
     let model: ScopedViewModel<ActiveViewState, ActiveAction>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 

--- a/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/ScopedCompositionView.swift
+++ b/ExampleProject/ScopedCompositionExamplePackage/Sources/ScopedCompositionExample/ScopedCompositionView.swift
@@ -11,7 +11,6 @@ typealias ScopedCompositionViewModel = ViewModel<
 /// shape: its render counter (and `DashboardView`'s) should never advance past 1.
 struct ScopedCompositionView: View {
     let viewModel: ScopedCompositionViewModel
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -63,7 +62,6 @@ struct ScopedCompositionView: View {
 /// Its counter should never advance past 1, even when the header re-renders.
 struct DashboardView: View {
     let model: ScopedViewModel<DashboardState, DashboardAction>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -86,7 +84,6 @@ struct DashboardView: View {
 /// can never be proven unchanged — the documented trade-off, visible in the counters.
 struct HeaderView: View {
     let model: ScopedViewModel<HeaderState, HeaderAction>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -107,7 +104,6 @@ struct HeaderView: View {
 /// The leaf: a two-way binding into the slice plus a counter button.
 struct BadgeView: View {
     let model: ScopedViewModel<BadgeState, BadgeAction>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 
@@ -133,7 +129,6 @@ struct BadgeView: View {
 /// projection is observation-live even though it can send nothing.
 struct FooterView: View {
     let model: ScopedViewModel<FooterState, Never>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
 

--- a/Sources/Lattice/Observation/ObservableState.swift
+++ b/Sources/Lattice/Observation/ObservableState.swift
@@ -44,6 +44,11 @@ public struct ObservableStateID: Equatable, Hashable, Sendable {
         self.init(storage: Storage(id: .location(UUID())))
     }
 
+    /// A shared identity for values that carry no observable content of their own, such as
+    /// payloadless enum cases. Tagging `_$inert` with a case index yields an id that is stable
+    /// across accesses and distinct across cases.
+    public static let _$inert = Self()
+
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.storage === rhs.storage || lhs.storage.id == rhs.storage.id
     }

--- a/Sources/Lattice/Presentation/ViewModel/ScopedViewModel.swift
+++ b/Sources/Lattice/Presentation/ViewModel/ScopedViewModel.swift
@@ -152,6 +152,107 @@ public struct ScopedViewModel<ChildState: ObservableState, ChildAction: Sendable
             )
         }
     }
+
+    extension ViewModel where ViewState: CasePathable, Action: CasePathable {
+        /// Projects this view model onto the payload of an enum case of view state, if that case
+        /// is currently active.
+        ///
+        /// This is the primitive form; ``scope(state:action:fileID:line:)`` is trapping sugar over
+        /// it for use inside a matched `switch` case. Reads are live: the returned scope
+        /// re-extracts the payload from the current view state on every access, so in-place payload
+        /// mutations are observed fine-grained. If the case deactivates while the scope is still
+        /// held (at most one transitional render), reads serve the payload captured at creation.
+        ///
+        /// Sends are embedded into this feature's action with `embed` and run on this view model's
+        /// action loop. A send can arrive after the case has deactivated; the interactor should
+        /// drop actions that no longer apply to the current state.
+        ///
+        /// - Parameters:
+        ///   - casePath: A case key path to an `@ObservableState` payload of the view state enum.
+        ///   - embed: A case key path that embeds the child action into this feature's action.
+        /// - Returns: A scope over the case's payload, or `nil` if the case is not active.
+        public func scopeIfActive<Child: ObservableState, ChildAction: Sendable>(
+            state casePath: CaseKeyPath<ViewState, Child>,
+            action embed: CaseKeyPath<Action, ChildAction>
+        ) -> ScopedViewModel<Child, ChildAction>? {
+            guard let snapshot = self.viewState[case: casePath] else { return nil }
+            return ScopedViewModel(
+                state: { [self] in self.viewState[case: casePath] ?? snapshot },
+                send: { [self] childAction in self.sendViewEvent(embed(childAction)) }
+            )
+        }
+
+        /// Projects this view model onto the payload of the currently active enum case of view
+        /// state, trapping if the case is not active.
+        ///
+        /// Call this only inside a `switch` case that just matched the same case:
+        ///
+        /// ```swift
+        /// switch viewModel.viewState {
+        /// case .loading:
+        ///     LoadingView()
+        /// case .success:
+        ///     SuccessView(model: viewModel.scope(state: \.success, action: \.success))
+        /// }
+        /// ```
+        ///
+        /// Body evaluation is synchronous on the main actor, so within a matched case this cannot
+        /// trap. Use ``scopeIfActive(state:action:)`` when the case may legitimately be inactive.
+        public func scope<Child: ObservableState, ChildAction: Sendable>(
+            state casePath: CaseKeyPath<ViewState, Child>,
+            action embed: CaseKeyPath<Action, ChildAction>,
+            fileID: StaticString = #fileID,
+            line: UInt = #line
+        ) -> ScopedViewModel<Child, ChildAction> {
+            guard let scoped = scopeIfActive(state: casePath, action: embed) else {
+                fatalError(
+                    """
+                    scope(state:action:) at \(fileID):\(line): scoped into case '\(casePath)' \
+                    while it is not the active case of the view state. Call this only inside a \
+                    switch case that matched the same case, or use scopeIfActive(state:action:).
+                    """
+                )
+            }
+            return scoped
+        }
+    }
+
+    extension ScopedViewModel where ChildState: CasePathable {
+        /// Projects this scope onto the payload of an enum case of the child slice, if active.
+        /// See ``ViewModel/scopeIfActive(state:action:)``.
+        public func scopeIfActive<CaseState: ObservableState, CaseAction: Sendable>(
+            state casePath: CaseKeyPath<ChildState, CaseState>,
+            action embed: CaseKeyPath<ChildAction, CaseAction>
+        ) -> ScopedViewModel<CaseState, CaseAction>? {
+            guard let snapshot = _state()[case: casePath] else { return nil }
+            let state = self._state
+            let send = self._send
+            return ScopedViewModel<CaseState, CaseAction>(
+                state: { state()[case: casePath] ?? snapshot },
+                send: { caseAction in send(embed(caseAction)) }
+            )
+        }
+
+        /// Projects this scope onto the payload of the currently active enum case of the child
+        /// slice, trapping if the case is not active. See ``ViewModel/scope(state:action:fileID:line:)``.
+        public func scope<CaseState: ObservableState, CaseAction: Sendable>(
+            state casePath: CaseKeyPath<ChildState, CaseState>,
+            action embed: CaseKeyPath<ChildAction, CaseAction>,
+            fileID: StaticString = #fileID,
+            line: UInt = #line
+        ) -> ScopedViewModel<CaseState, CaseAction> {
+            guard let scoped = scopeIfActive(state: casePath, action: embed) else {
+                fatalError(
+                    """
+                    scope(state:action:) at \(fileID):\(line): scoped into case '\(casePath)' \
+                    while it is not the active case of the child slice. Call this only inside a \
+                    switch case that matched the same case, or use scopeIfActive(state:action:).
+                    """
+                )
+            }
+            return scoped
+        }
+    }
 #endif
 
 extension ViewModel {

--- a/Sources/LatticeMacros/Plugins/Derived/ObservableStateMacro.swift
+++ b/Sources/LatticeMacros/Plugins/Derived/ObservableStateMacro.swift
@@ -409,7 +409,7 @@ enum ObservableStateCase {
             } else {
                 return """
                     case .\(element.name.text):
-                    return ObservableStateID()._$tag(\(tag))
+                    return ObservableStateID._$inert._$tag(\(tag))
                     """
             }
         case .ifConfig(let configs):

--- a/Tests/LatticeMacrosTests/ObservableStateMacroTests.swift
+++ b/Tests/LatticeMacrosTests/ObservableStateMacroTests.swift
@@ -586,7 +586,7 @@
                   public var _$id: Lattice.ObservableStateID {
                     switch self {
                     case .foo:
-                      return ObservableStateID()._$tag(0)
+                      return ObservableStateID._$inert._$tag(0)
                     }
                   }
 

--- a/Tests/LatticeTests/PresentationTests/EnumCaseScopingTests.swift
+++ b/Tests/LatticeTests/PresentationTests/EnumCaseScopingTests.swift
@@ -1,0 +1,182 @@
+import CasePaths
+import Foundation
+import Observation
+import Testing
+
+@testable import Lattice
+
+private final class ChangeProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hasChanged = false
+    var didChange: Bool { lock.withLock { hasChanged } }
+    func mark() { lock.withLock { hasChanged = true } }
+}
+
+@ObservableState private struct SuccessViewState: Equatable, Sendable {
+    var title: String
+    var count: Int
+}
+
+@CasePathable
+@ObservableState private enum PhaseViewState: Equatable, Sendable, DefaultValueProvider {
+    static let defaultValue = Self.loading
+    case loading
+    case success(SuccessViewState)
+}
+
+private struct PhaseDomain: Equatable, Sendable {
+    var isLoaded = false
+    var title = "t"
+    var count = 0
+    var tick = 0
+}
+
+@CasePathable private enum SuccessAction: Sendable {
+    case titleChanged(String)
+    case incremented
+}
+
+@CasePathable private enum PhaseAction: Sendable {
+    case load
+    case reset
+    case tick
+    case success(SuccessAction)
+}
+
+private struct PhaseInteractor: Interactor, Sendable {
+    typealias DomainState = PhaseDomain
+    typealias Action = PhaseAction
+    var body: some InteractorOf<Self> {
+        Interact { state, action in
+            switch action {
+            case .load: state.isLoaded = true
+            case .reset: state.isLoaded = false
+            case .tick: state.tick += 1
+            case .success(let action):
+                // Late sends after the case deactivated are dropped here, by design.
+                guard state.isLoaded else { return .none }
+                switch action {
+                case .titleChanged(let t): state.title = t
+                case .incremented: state.count += 1
+                }
+            }
+            return .none
+        }
+    }
+}
+
+/// Fine-grained regime: transitions rebuild the case; steady-state updates mutate the payload
+/// in place through the case.
+private struct PhaseReducer: ViewStateReducer, Sendable {
+    typealias DomainState = PhaseDomain
+    typealias ViewState = PhaseViewState
+    // PhaseViewState: DefaultValueProvider supplies the initial view state.
+    var body: some ViewStateReducerOf<Self> {
+        BuildViewState<PhaseDomain, PhaseViewState> { s, v in
+            guard s.isLoaded else {
+                v = .loading
+                return
+            }
+            if v.is(\.success) {
+                v.modify(\.success) {  // in-place: payload registrar fires leaves only
+                    $0.title = s.title
+                    $0.count = s.count
+                }
+            } else {
+                v = .success(SuccessViewState(title: s.title, count: s.count))  // case transition
+            }
+        }
+    }
+}
+
+@MainActor
+@Suite struct EnumCaseScopingTests {
+    private func makeViewModel() -> ViewModel<Feature<PhaseAction, PhaseDomain, PhaseViewState>> {
+        ViewModel(
+            initialDomainState: PhaseDomain(),
+            feature: Feature(interactor: PhaseInteractor(), reducer: PhaseReducer())
+        )
+    }
+
+    // MARK: Prerequisite fix (_$inert)
+
+    @Test func payloadlessCaseIsStable_unrelatedReduceDoesNotFireCoarse() {
+        let vm = makeViewModel()  // .loading
+        let probe = ChangeProbe()
+        withObservationTracking { _ = vm.viewState } onChange: { probe.mark() }
+
+        vm.sendViewEvent(.tick)  // domain changes; view state stays .loading
+        #expect(!probe.didChange)  // fails before the _$inert fix
+    }
+
+    @Test func caseChangeStillFiresCoarse() {
+        let vm = makeViewModel()
+        let probe = ChangeProbe()
+        withObservationTracking { _ = vm.viewState } onChange: { probe.mark() }
+
+        vm.sendViewEvent(.load)  // .loading -> .success
+        #expect(probe.didChange)
+    }
+
+    // MARK: Case scoping
+
+    @Test func trappingScopeReadsLivePayload() {
+        let vm = makeViewModel()
+        vm.sendViewEvent(.load)
+        let success = vm.scope(state: \.success, action: \.success)
+        #expect(success.title == "t")
+
+        success.sendViewEvent(.titleChanged("new"))  // in-place reduce
+        #expect(success.title == "new")  // live re-extraction, not a snapshot
+    }
+
+    @Test func scopeIfActiveReturnsNilForInactiveCase() {
+        let vm = makeViewModel()  // .loading
+        #expect(vm.scopeIfActive(state: \.success, action: \.success) == nil)
+    }
+
+    @Test func inPlacePayloadMutationIsFineGrained() {
+        let vm = makeViewModel()
+        vm.sendViewEvent(.load)
+        let success = vm.scope(state: \.success, action: \.success)
+
+        let titleProbe = ChangeProbe()
+        withObservationTracking { _ = success.title } onChange: { titleProbe.mark() }
+        let coarseProbe = ChangeProbe()
+        withObservationTracking { _ = vm.viewState } onChange: { coarseProbe.mark() }
+
+        success.sendViewEvent(.incremented)  // in-place: only count changes
+        #expect(!titleProbe.didChange)  // sibling leaf not invalidated
+        #expect(!coarseProbe.didChange)  // switch not re-rendered
+    }
+
+    @Test func caseFlipServesCreationSnapshotWithoutCrashing() {
+        let vm = makeViewModel()
+        vm.sendViewEvent(.load)
+        let success = vm.scope(state: \.success, action: \.success)
+
+        vm.sendViewEvent(.reset)  // .success -> .loading; scope is now stale
+        #expect(success.title == "t")  // creation snapshot, no trap/crash
+    }
+
+    @Test func lateSendAfterCaseFlipIsDroppedByInteractor() {
+        let vm = makeViewModel()
+        vm.sendViewEvent(.load)
+        let success = vm.scope(state: \.success, action: \.success)
+        vm.sendViewEvent(.reset)
+
+        success.sendViewEvent(.incremented)  // arrives while .loading
+        vm.sendViewEvent(.load)
+        #expect(vm.viewState[case: \.success]?.count == 0)  // guard dropped it
+    }
+
+    @Test func bindingThroughCaseScope() {
+        let vm = makeViewModel()
+        vm.sendViewEvent(.load)
+        let success = vm.scope(state: \.success, action: \.success)
+        let binding = success.binding(\.title, sending: \.titleChanged)
+        #expect(binding.wrappedValue == "t")
+        binding.wrappedValue = "typed"
+        #expect(binding.wrappedValue == "typed")
+    }
+}

--- a/specs/enum-case-scoping.md
+++ b/specs/enum-case-scoping.md
@@ -597,7 +597,7 @@ Payloadless cases (`.loading`, `.idle`) are reassigned on every reduce; their `_
 ids make those assignments identity-equal no-ops.
 
 The root view is a plain exhaustive `switch` over `viewModel.viewState`, with load/reset
-buttons outside the switch and a `ponytail:`-marked render counter (the same instrumentation as
+buttons outside the switch and a render counter (the same instrumentation as
 Spec B's demo views) on **every** view in the chain. The view tree mirrors the state tree:
 
 - `PhaseExampleView` — owns the outer `switch`; `.success` renders

--- a/specs/enum-case-scoping.md
+++ b/specs/enum-case-scoping.md
@@ -521,11 +521,14 @@ Example", navigation title "Enum Case Scoping", `destinationView` `PhaseExampleA
 Use the example project's macro conventions (`@Interactor`, `@ViewStateReducer` with
 `Self.buildViewState`) rather than this spec's protocol-spelled test fixtures.
 
-The demo must make three things visible in a running app: the fine-grained in-place path
-through a case scope, the coarse case-change path, and the `_$inert` fix.
+The demo must make four things visible in a running app: the fine-grained in-place path
+through a case scope (down a deep chain of nested slices), the coarse case-change path at
+both enum levels, and the `_$inert` fix.
 
-Shape — the whole view state is the enum, same names as this spec's fixtures, with a `tick`
-added to the success payload so the tick stream is visible on screen:
+Shape — the whole view state is the enum, and the success payload is a deep chain of nested
+`@ObservableState` slices (`Success > Session > Telemetry > Subphase > Active`) with a
+`Summary` sibling branch at the first level and a nested sub-phase **enum** at the third, so
+the render counters can show exactly which boundaries a change crosses:
 
 ```swift
 @CasePathable
@@ -538,93 +541,102 @@ enum PhaseViewState: Equatable, Sendable {
 @ObservableState
 struct SuccessViewState: Equatable, Sendable {
     var title: String
-    var count: Int
-    var tick: Int
+    var summary: SummaryViewState    // sibling branch: count
+    var session: SessionViewState    // deep branch: name > telemetry
+}
+
+@ObservableState
+struct SessionViewState: Equatable, Sendable {
+    var name: String
+    var telemetry: TelemetryViewState    // status + nested sub-phase enum
+}
+
+@ObservableState
+struct TelemetryViewState: Equatable, Sendable {
+    var status: String
+    var subphase: SubphaseViewState
+}
+
+@CasePathable
+@ObservableState
+enum SubphaseViewState: Equatable, Sendable {
+    case idle
+    case active(ActiveViewState)    // deep leaf: tick + note
 }
 ```
 
-Domain state is flat (`isLoaded`/`title`/`count`/`tick`); the root event enum `PhaseEvent` has
-`loadTapped`, `loaded`, `resetTapped`, `startTicking`, `tick`, and `success(SuccessAction)`
-cases, with `SuccessAction` as in the fixtures (`titleChanged(String)`/`incremented`). The
-interactor:
+Each level is rendered by a thin child view holding a `ScopedViewModel` chained with Spec B's
+key-path `scope` from the case scope; the inner sub-phase is case-scoped via this spec's
+`ScopedViewModel.scope(state:action:)` case overload
+(`model.scope(state: \.subphase, action: \.subphase).scope(state: \.active, action: \.active)`),
+demonstrating case scoping below the root. The action enums nest the same way
+(`ActiveAction ⊂ SubphaseAction ⊂ TelemetryAction ⊂ SessionAction ⊂ SuccessAction ⊂
+PhaseEvent`, with `SummaryAction` as the sibling branch).
+
+Domain state is flat (`isLoaded`/`isActive`/`title`/`count`/`sessionName`/`status`/`tick`/
+`note`, plus an `isTicking` guard flag so the tick stream is started at most once — the
+`TimerLeakExamplePackage` convention). The interactor:
 
 - `.loadTapped` fakes an async load: `return .perform { try? await clock.sleep(for: .seconds(1));
   return .loaded }` (the `.perform` convention used by `SearchExamplePackage`'s interactors);
   `.loaded` sets `isLoaded = true` and `.resetTapped` clears it.
 - A once-per-second tick stream via `.observe` (the `TimerLeakExamplePackage` convention),
   started from a view event on appear, bumps `state.tick` — the unrelated-reduce driver for the
-  `_$inert` behavior below.
-- `.success(...)` actions are guarded on `isLoaded` and dropped otherwise (the late-send
-  discipline from "Late sends").
+  `_$inert` behavior below, and the deep-leaf driver while the `.active` sub-phase is showing.
+- `.success(.session(.telemetry(.startTapped/.stopTapped)))` toggles `isActive`, driving the
+  inner sub-phase case.
+- `.success(...)` actions are guarded on `isLoaded` (and the leaf's `.noteChanged` additionally
+  on `isActive`) and dropped otherwise (the late-send discipline from "Late sends").
 
-The reducer keeps this spec's two-regimes discipline exactly as `PhaseReducer` does: `.loading`
-when not loaded; when loaded, **in place** via `v.modify(\.success) { ... }` if already in the
-case (title, count, and tick), wholesale `v = .success(SuccessViewState(...))` only on the
-`.loading → .success` transition.
+The reducer keeps this spec's two-regimes discipline at **both** enum levels: `.loading` when
+not loaded; wholesale `v = .success(SuccessViewState(...))` only on the `.loading → .success`
+transition; otherwise **in place** via `v.modify(\.success) { ... }` (title, count, name,
+status), and inside that, `.idle` / wholesale `.active(ActiveViewState(...))` only on sub-phase
+transitions with `subphase.modify(\.active) { ... }` (tick, note) while staying in the case.
+Payloadless cases (`.loading`, `.idle`) are reassigned on every reduce; their `_$inert`-stable
+ids make those assignments identity-equal no-ops.
 
 The root view is a plain exhaustive `switch` over `viewModel.viewState`, with load/reset
 buttons outside the switch and a `ponytail:`-marked render counter (the same instrumentation as
-Spec B's demo views) counting evaluations of the switch-owning body:
+Spec B's demo views) on **every** view in the chain. The view tree mirrors the state tree:
 
-```swift
-struct PhaseExampleView: View {
-    let viewModel: PhaseExampleViewModel
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
-    private final class Renders { var count = 0 }
-    private let renders = Renders()
+- `PhaseExampleView` — owns the outer `switch`; `.success` renders
+  `SuccessView(model: viewModel.scope(state: \.success, action: \.success))`; starts the tick
+  stream from `.task`.
+- `SuccessView` — title `TextField` via `binding(\.title, sending: \.titleChanged)`;
+  `SummaryView(model: model.scope(state: \.summary, action: \.summary))` (sibling branch) and
+  `SessionView(model: model.scope(state: \.session, action: \.session))`.
+- `SummaryView` — count + Increment button.
+- `SessionView` — reads `name`, scopes deeper to `TelemetryView`.
+- `TelemetryView` — reads `status`; owns the **inner** `switch` over `model.subphase` (the
+  sub-phase container read registers its identity, so this view re-renders on inner case
+  changes only); `.active` renders `ActiveView` via the chained case scope shown above;
+  Start/Stop buttons drive the sub-phase.
+- `ActiveView` — the deep leaf: `Tick:` text and a note `TextField` via
+  `binding(\.note, sending: \.noteChanged)`.
 
-    var body: some View {
-        renders.count += 1
-        return VStack(alignment: .leading) {
-            switch viewModel.viewState {      // coarse read: re-renders on case change only
-            case .loading:
-                ProgressView("Loading…")
-            case .success:
-                SuccessView(model: viewModel.scope(state: \.success, action: \.success))
-            }
-            Button("Load") { viewModel.sendViewEvent(.loadTapped) }
-            Button("Reset") { viewModel.sendViewEvent(.resetTapped) }
-            Text("PhaseExampleView renders: \(renders.count)")
-                .font(.caption).foregroundStyle(.secondary)
-        }
-        .task { await viewModel.sendViewEvent(.startTicking).finish() }
-    }
-}
+Expected, demonstrable behavior (all visible in the render counters):
 
-struct SuccessView: View {
-    let model: ScopedViewModel<SuccessViewState, SuccessAction>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
-    private final class Renders { var count = 0 }
-    private let renders = Renders()
-
-    var body: some View {
-        renders.count += 1
-        return VStack(alignment: .leading) {
-            TextField("Title", text: model.binding(\.title, sending: \.titleChanged))
-            Button("Increment") { model.sendViewEvent(.incremented) }
-            Text("Count: \(model.count)   Tick: \(model.tick)")
-            Text("SuccessView renders: \(renders.count)")
-                .font(.caption).foregroundStyle(.secondary)
-        }
-    }
-}
-```
-
-Expected, demonstrable behavior:
-
-- Typing in the **Title** field or tapping **Increment** (in-place payload mutations through
-  `v.modify(\.success)`): only `SuccessView renders:` advances. The switch root registered only
-  the coarse `\.viewState`, whose root `_$id` is untouched by in-place mutation, so
-  `PhaseExampleView renders:` stays put.
-- Tapping **Load** or **Reset** (case change): `PhaseExampleView renders:` advances — the root
-  `_$id` changed, the coarse fire re-renders the switch, and the success subtree is built or
-  torn down. This is the intended coarse channel, not a regression.
+- Ticks while `.active` is showing, or typing in the **Note** field (in-place mutations of the
+  deep leaf through both `modify` levels): only `ActiveView renders:` advances. Every
+  intermediate counter (`TelemetryView`, `SessionView`, `SuccessView`) and the sibling
+  (`SummaryView`) stay put, as does the root switch.
+- Tapping **Increment** (sibling branch): only `SummaryView renders:` advances.
+- Tapping **Start**/**Stop** (inner case change): `TelemetryView renders:` advances — the
+  sub-phase identity changed, so the inner switch re-renders and builds/tears down the
+  `ActiveView` subtree. `SessionView` and everything above stay put.
+- Tapping **Load**/**Reset** (outer case change): `PhaseExampleView renders:` advances — the
+  root `_$id` changed, the coarse fire re-renders the outer switch, and the success subtree is
+  built or torn down. This is the intended coarse channel, not a regression.
 - While sitting in `.loading`, the tick stream keeps reducing unrelated domain state once per
-  second, and `PhaseExampleView renders:` does **not** advance. This is the `_$inert` fix made
-  visible: before it, `.loading._$id` minted a fresh UUID per access, the `_modify` gate saw a
-  changed root `_$id` on every reduce, and the switch would re-render once per second while
-  showing an unchanged spinner. (While in `.success`, the same ticks are in-place payload
-  mutations: `Tick:` and `SuccessView renders:` advance each second, the switch still does not.)
+  second, and **no** counter advances. This is the `_$inert` fix made visible: before it,
+  `.loading._$id` minted a fresh UUID per access, the `_modify` gate saw a changed root `_$id`
+  on every reduce, and the switch would re-render once per second while showing an unchanged
+  spinner. (The same holds one level down: ticks while the sub-phase sits in `.idle` advance
+  nothing, because `.idle`'s id is `_$inert`-stable too.)
+- Typing in the **Title** field re-renders `SuccessView` — and, because scopes are recreated
+  by the render that owns them, its scoped children re-render with it (Spec B's documented
+  trade-off, already visible in the Spec B demo).
 
 This is the manual counterpart to `payloadlessCaseIsStable_*`, `inPlacePayloadMutationIsFineGrained`,
 and `caseChangeStillFiresCoarse`.

--- a/specs/fine-grained-observation.md
+++ b/specs/fine-grained-observation.md
@@ -375,12 +375,11 @@ Shape:
   `setTitle(String)` / `bumpCount`, each mutating only its own slice **in place** in the reducer.
 - A root view that composes two sibling subviews, `HeaderView` and `FooterView`, each given the
   same `ViewModel<FineGrainedFeature>`.
-- Each subview holds a `ponytail:`-marked render counter so taps prove which subview re-rendered:
+- Each subview holds a render counter so taps prove which subview re-rendered:
 
 ```swift
 struct HeaderView: View {
     let viewModel: ViewModel<FineGrainedFeature>
-    // ponytail: render counter is demo-only instrumentation, not a real pattern
     private final class Renders { var count = 0 }
     private let renders = Renders()
     var body: some View {

--- a/specs/scoped-view-composition.md
+++ b/specs/scoped-view-composition.md
@@ -623,7 +623,7 @@ The root view hosts two buttons that drive non-leaf mutations, mirroring the fin
 demo's button row: **Rename header** (sends `.dashboard(.header(.titleChanged(...)))` with a
 random suffix) and **Update footer** (sends `.setFooter(...)`). `BadgeView` is the leaf and
 carries the `binding(_:sending:)` text field plus a counter button. Every view holds a
-`ponytail:`-marked render counter (same instrumentation as `FineGrainedExamplePackage`'s
+render counter (same instrumentation as `FineGrainedExamplePackage`'s
 `HeaderView`) so re-render boundaries are visible:
 
 ```swift


### PR DESCRIPTION
## Summary
- Implements [specs/enum-case-scoping.md](../blob/enum-case-scoping/specs/enum-case-scoping.md) (Spec C): `scope(state:action:)` (trapping) and `scopeIfActive(state:action:)` case-path overloads on `ViewModel` and `ScopedViewModel`, projecting an enum view-state case's payload into a live `ScopedViewModel` with fine-grained observation and creation-snapshot fallback for the transitional render after a case flips.
- Prerequisite `_$inert` fix: payloadless enum cases now derive a stable `_$id` (`ObservableStateID._$inert._$tag(_:)`), so unrelated reduces no longer fire the coarse `\.viewState` while a payloadless case is active. Cases with non-`ObservableState` payloads intentionally keep unstable ids (the coarse fire is their only re-render channel).
- Demo: new phase-enum screen in `ScopedCompositionExamplePackage` with a deep chain (`Success > Session > Telemetry > Subphase > Active`, sibling `Summary`, inner sub-phase enum case-scoped below the root) and render counters on every view to make the observation boundaries visible.

## Test plan
- [x] `EnumCaseScopingTests`: 8/8, including both `_$inert` regression tests
- [x] `LatticeMacrosTests`: 25 tests, 0 failures (payloadless-enum expansion snapshots updated)
- [x] Full suite: 129 tests / 33 suites, 0 failures (serial; the parallel-runner wedge is a pre-existing environment issue in time-based tests)
- [x] Demo package tests 4/4; `xcodebuild` ExampleProject for iOS Simulator: BUILD SUCCEEDED
- [ ] Manual: render-counter behavior in the simulator (leaf ticks re-render only `ActiveView`; Start/Stop re-renders only the inner switch; Load/Reset re-renders the root; ticks while `.loading` re-render nothing)

Made with [Cursor](https://cursor.com)